### PR TITLE
Added form application for reading plain forms

### DIFF
--- a/gms-services/src/main/resources/documentation/acm-forms.properties
+++ b/gms-services/src/main/resources/documentation/acm-forms.properties
@@ -14,7 +14,7 @@ frevvo.admin.user=admin
 frevvo.admin.password=admin
 frevvo.designer.user=acm
 # Application ids where plain forms are present (comma separated, example: _IgbIMDnTEeSjTrBIsoKK0g,_ubJWgTBpEeWlqfoL7GxXoQ)
-frevvo.plain.form.application.ids=_IgbIMDnTEeSjTrBIsoKK0g,_TZ9mQDFoEeWU67Y3hJP2ZA
+frevvo.plain.form.application.ids=_IgbIMDnTEeSjTrBIsoKK0g,_71o_8Y3jEeW7uvbfEqi_gA
 
 # The timezone that need for Date/Time fields in the forms
 # List of timezones: http://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
Adding GMS Frevvo form application id in the acm-forms.properties to be able to read plain forms

Action needed:
1. Please update property `frevvo.plain.form.application.ids` in your **$HOME/.acm/acm-forms.properties** with following data:
`frevvo.plain.form.application.ids=_IgbIMDnTEeSjTrBIsoKK0g,_71o_8Y3jEeW7uvbfEqi_gA`