### PR TITLE
Create automatic folder structure for award

### DIFF
--- a/gms-services/src/main/java/com/arkcase/gms/pipeline/postsave/CaseFileFolderStructureHandler.java
+++ b/gms-services/src/main/java/com/arkcase/gms/pipeline/postsave/CaseFileFolderStructureHandler.java
@@ -1,0 +1,127 @@
+package com.arkcase.gms.pipeline.postsave;
+
+import com.arkcase.gms.model.GmsConstants;
+import com.arkcase.gms.model.Grant;
+import com.armedia.acm.plugins.casefile.model.CaseFile;
+import com.armedia.acm.plugins.casefile.pipeline.CaseFilePipelineContext;
+import com.armedia.acm.plugins.casefile.utility.CaseFileEventUtility;
+import com.armedia.acm.plugins.ecm.model.AcmContainer;
+import com.armedia.acm.plugins.ecm.service.AcmFolderService;
+import com.armedia.acm.plugins.ecm.service.EcmFileService;
+import com.armedia.acm.services.pipeline.exception.PipelineProcessException;
+import com.armedia.acm.services.pipeline.handler.PipelineHandler;
+import org.json.JSONArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+
+import java.util.Date;
+
+
+public class CaseFileFolderStructureHandler extends com.armedia.acm.plugins.casefile.pipeline.postsave.CaseFileFolderStructureHandler
+{
+    /**
+     * Case File event utility.
+     */
+    private CaseFileEventUtility caseFileEventUtility;
+
+    /**
+     * Case File folder structure.
+     */
+    private String folderStructureAsString;
+
+    /**
+     * CMIS service.
+     */
+    private EcmFileService ecmFileService;
+
+    /**
+     * ACM folder service.
+     */
+    private AcmFolderService acmFolderService;
+
+    /**
+     * Logger instance.
+     */
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void execute(CaseFile entity, CaseFilePipelineContext pipelineContext) throws PipelineProcessException
+    {
+        if (entity != null && entity instanceof Grant)
+        {
+            Grant grant = (Grant) entity;
+            if (GmsConstants.TYPE_AWARDED_GRANT.equalsIgnoreCase(grant.getGrantType()))
+            {
+                Authentication auth = pipelineContext.getAuthentication();
+
+                if (pipelineContext.isNewCase())
+                {
+                    createFolderStructure(entity);
+                    caseFileEventUtility.raiseEvent(entity, entity.getStatus(), new Date(), pipelineContext.getIpAddress(), auth.getName(), auth);
+                } else
+                {
+                    caseFileEventUtility.raiseEvent(entity, "updated", new Date(), pipelineContext.getIpAddress(), auth.getName(), auth);
+                }
+            }
+        }
+    }
+
+
+    private void createFolderStructure(CaseFile caseFile)
+    {
+        if (folderStructureAsString != null && !folderStructureAsString.isEmpty())
+        {
+            try
+            {
+                log.debug("Folder Structure [{}]", folderStructureAsString);
+                JSONArray folderStructure = new JSONArray(folderStructureAsString);
+                AcmContainer container = ecmFileService.getOrCreateContainer(caseFile.getObjectType(), caseFile.getId());
+                acmFolderService.addFolderStructure(container, container.getFolder(), folderStructure);
+            } catch (Exception e)
+            {
+                log.error("Cannot create folder structure.", e);
+            }
+        }
+    }
+
+    public CaseFileEventUtility getCaseFileEventUtility()
+    {
+        return caseFileEventUtility;
+    }
+
+    public void setCaseFileEventUtility(CaseFileEventUtility caseFileEventUtility)
+    {
+        this.caseFileEventUtility = caseFileEventUtility;
+    }
+
+    public String getFolderStructureAsString()
+    {
+        return folderStructureAsString;
+    }
+
+    public void setFolderStructureAsString(String folderStructureAsString)
+    {
+        this.folderStructureAsString = folderStructureAsString;
+    }
+
+    public EcmFileService getEcmFileService()
+    {
+        return ecmFileService;
+    }
+
+    public void setEcmFileService(EcmFileService ecmFileService)
+    {
+        this.ecmFileService = ecmFileService;
+    }
+
+    public AcmFolderService getAcmFolderService()
+    {
+        return acmFolderService;
+    }
+
+    public void setAcmFolderService(AcmFolderService acmFolderService)
+    {
+        this.acmFolderService = acmFolderService;
+    }
+}

--- a/gms-services/src/main/resources/documentation/caseFilePlugin.properties
+++ b/gms-services/src/main/resources/documentation/caseFilePlugin.properties
@@ -1,0 +1,133 @@
+#case file email folder
+casefile.email.folder.relative.path=emails-received
+#case file email regex to match case number
+casefile.email.regex.case_number=[\\d]{4}[\\d]{2}[\\d]{2}_[\\d]*
+#case file email handler is enabled
+casefile.email.handler.enabled=true
+
+#types available for copy are: history, people, participants, tasks
+casefile.split.typesToCopy=history,people,participants
+
+casefile.merge.exclude_document_types=case_file_xml,case_file
+
+casefile.case-types=Education Waiver Request,Pension Waiver Request,Disability Waiver Request,Congressional Response,Product Tampering,New Drug Application Fraud,Clinical Investigator Fraud,Murder,Drug Trafficking,Labor Racketeering,Fraud,Payoff,Theft or misuse of asset,Extortion,Embezzlement,Investor Complaint,Background Investigation,Agricultural,Arson,Better Business Dispute,Domestic Dispute,Government,Local,Pollution,Major Indictable,Minor Indictable,Summary Matter,Project
+
+search.tree.filter=[{"desc": "All Open Cases", "name":"all-open-cases", "value":"fq=-status_s:COMPLETE AND -status_s:DELETE AND -status_s:CLOSED", "default":true  } \
+,{"desc": "All I've Created", "name":"my-created-cases", "value":"fq=author_s:${user}" } \
+,{"desc": "All I'm Assigned", "name":"my-assigned-cases", "value":"fq=assignee_s:${user}" } \
+,{"desc": "All I'm Following", "name":"my-following-cases", "value":"fq={!join from=parent_object_id_s to=object_id_s}(owner_s:${user} AND object_type_s:SUBSCRIPTION)"} \
+,{"desc": "All Closed", "name":"all-closed-cases", "value":"fq=status_s:CLOSED"}   \
+,{"desc": "(No Filter)", "name":"", "value":""} \
+]
+
+search.tree.sort=[{"desc": "Sort Date Asc", "name":"sort-date-asc", "value":"create_tdt ASC"} \
+,{"desc": "Sort Date Desc", "name":"sort-date-desc", "value":"create_tdt DESC"} \
+,{"desc": "Sort Case ID Asc", "name":"sort-case-id-asc", "value":"object_id_s ASC"}  \
+,{"desc": "Sort Case ID Dece", "name":"sort-case-id-desc", "value":"object_id_s DESC"} \
+,{"desc": "Sort By Case Name", "name":"sort-by-name-asc", "value":"name ASC"} \
+,{"desc": "(No Sort)", "name":"", "value":"", "default":true} \
+]
+
+# The properties where the search query should be executed (comma separated, for example: title_parseable,description_no_html_tags_parseable ... etc)
+search.tree.searchQuery=title_parseable
+
+fileTypes=[{"type": "other", "label": "Other"}]
+
+#Outlook integration
+#this properties should be enabled if outlook integration is desired
+casefile.auto_create_calendar_folder=true
+casefile.delete_calendar_folder_after_case_closed=true
+
+## Dashboard SOLR queries
+
+# Get all case_file by user that are not closed, deleted or completed
+solr.casefile.all.not.closed.by.user=object_type_s:CASE_FILE&fq=creator_lcs=?&fq=-status_s:COMPLETE&fq=-status_s:DELETE&fq=-status_s:CLOSED
+
+# Get all case_files grouped by status
+solr.casefile.all.group.by.status=object_type_s:CASE_FILE&group=true&group.field=status_lcs&group.limit=0
+
+## Case File tree root name format. If this property not exist or it's empty, the default value will be taken: Acm.goodValue(objSolr.title_parseable) + ' (' + Acm.goodValue(objSolr.name) + ')'
+casefile.tree.root.name.expression=Acm.goodValue(objSolr.title_parseable)
+
+# which JSP to use for case file details, either casefile or ebrief
+jsp=casefile
+#jsp=ebrief
+
+# The subject for creating calendar event for next court hearing date
+casefile.next.court.hearing.date.calendar.subject=Court Hearing Date
+
+## Initial folder structure while creating case file (just leave blank or remove it if the folder structure should not be created)
+
+# "attachment" indicates under which folder should be saved attachments. ONLY ONE should have value "true", all other should have "false"
+# If multiple folders will have "attachment": true, then the last one will take effect (the attachments will go to the last one with "attachment": true)
+casefile.folder.structure=[ \
+	{ \
+		"name": "Monitoring", \
+		"attachment": false, \
+		"children": [ \
+		{ \
+			"name": "Regular Contact", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Desk Audits", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Expenditure", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Corrective Action Plans", \
+			"attachment": false, \
+			"children": null \
+		}] \
+	}, \
+	{ \
+		"name": "Closeout", \
+		"attachment": false, \
+		"children": [{ \
+			"name": "Invoices", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Final reports", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Programmatic", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Financial", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Property", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Others per award terms", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Signed Refunds, Rebates, Credits Form", \
+			"attachment": false, \
+			"children": null \
+		}, \
+		{ \
+			"name": "Audit sub-award", \
+			"attachment": false, \
+			"children": null \
+		}] \
+	} \
+] \

--- a/gms-services/src/main/resources/spring/spring-library-case-file.xml
+++ b/gms-services/src/main/resources/spring/spring-library-case-file.xml
@@ -8,4 +8,13 @@
         <property name="ruleSpreadsheetFilename" value="drools-case-file-rules-gms.xlsx"/>
     </bean>
 
+    <!-- Override ArkCase caseFileFolderStructureHandler -->
+    <bean id="caseFileFolderStructureHandler"
+          class="com.arkcase.gms.pipeline.postsave.CaseFileFolderStructureHandler">
+        <property name="caseFileEventUtility" ref="caseFileEventUtility"/>
+        <property name="folderStructureAsString" value="${casefile.folder.structure}"/>
+        <property name="ecmFileService" ref="ecmFileService"/>
+        <property name="acmFolderService" ref="acmFolderService"/>
+    </bean>
+
 </beans>


### PR DESCRIPTION
New requirement is that we need to have following folder structure on Award creation.

Monitoring (Parent Folder)
Regular Contact (Sub Folder)
Desk Audits (Sub Folder)
Expenditure (Sub Folder)
Corrective Action Plans (Sub Folder)
Closeout (Parent Folder)
Invoices (Sub Folder)
final reports (Sub Folder)
Programmatic (Sub Folder)
Financial (Sub Folder)
Property (Sub Folder)
Others per award terms (Sub Folder)
Signed Refunds, Rebates, Credits Form (Sub Folder)
Audit sub-award (Sub Folder)


**Action required : Need to update the casefile.folder.structure property in the caseFilePlugin.properties.**