### PR TITLE
AFDP-1690: Dashboard - All Widgets defaulted to 5 results

### DIFF
--- a/gms-user-interface/src/main/resources/META-INF/resources/resources/custom_modules/dashboard/module_config/config.json
+++ b/gms-user-interface/src/main/resources/META-INF/resources/resources/custom_modules/dashboard/module_config/config.json
@@ -170,8 +170,12 @@
       "id": "awardedGrants",
       "title": "Awarded Grants",
       "enableFiltering": false,
-      "paginationPageSizes": [25, 50, 75],
-      "paginationPageSize": 25,
+      "paginationPageSizes": [
+        5,
+        10,
+        25
+      ],
+      "paginationPageSize": 5,
       "columnDefs": [
         {
           "name": "object_id_s",
@@ -205,8 +209,12 @@
       "id": "unawardedGrants",
       "title": "Un-Awarded Grants",
       "enableFiltering": false,
-      "paginationPageSizes": [25, 50, 75],
-      "paginationPageSize": 25,
+      "paginationPageSizes": [
+        5,
+        10,
+        25
+      ],
+      "paginationPageSize": 5,
       "columnDefs": [
         {
           "name": "object_id_s",


### PR DESCRIPTION
Awarded and un-warded dashboard widgets need to be defaulted to 5 results. Also the results options should be 5, 10, 25.